### PR TITLE
More metrics

### DIFF
--- a/harness-active_publisher.gemspec
+++ b/harness-active_publisher.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "activesupport", ">= 3.2"
   spec.add_runtime_dependency "harness", ">= 2.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"

--- a/lib/harness/active_publisher.rb
+++ b/lib/harness/active_publisher.rb
@@ -1,7 +1,10 @@
 require "harness/active_publisher/version"
 
-::ActiveSupport::Notifications.subscribe "async_queue_size.active_publisher" do |async_queue_size|
-  ::Harness.counter "active_publisher.async_queue_size", async_queue_size
+require "harness"
+require "active_support"
+
+::ActiveSupport::Notifications.subscribe "async_queue_size.active_publisher" do |_, _, _, _, async_queue_size|
+  ::Harness.count "active_publisher.async_queue_size", async_queue_size
 end
 
 ::ActiveSupport::Notifications.subscribe "message_dropped.active_publisher" do

--- a/lib/harness/active_publisher.rb
+++ b/lib/harness/active_publisher.rb
@@ -11,6 +11,13 @@ end
   ::Harness.increment "active_publisher.message_dropped"
 end
 
+::ActiveSupport::Notifications.subscribe "message_published.active_publisher" do |*args|
+  ::Harness.increment "active_publisher.messages_published"
+
+  event = ::ActiveSupport::Notifications::Event.new(*args)
+  ::Harness.timing "active_publisher.publish_latency", event.duration
+end
+
 ::ActiveSupport::Notifications.subscribe "wait_for_async_queue.active_publisher" do |*args|
   event = ::ActiveSupport::Notifications::Event.new(*args)
   ::Harness.timing "active_publisher.waiting_for_async_queue", event.duration

--- a/lib/harness/active_publisher.rb
+++ b/lib/harness/active_publisher.rb
@@ -1,5 +1,13 @@
 require "harness/active_publisher/version"
 
+::ActiveSupport::Notifications.subscribe "async_queue_size.active_publisher" do |async_queue_size|
+  ::Harness.counter "active_publisher.async_queue_size", async_queue_size
+end
+
+::ActiveSupport::Notifications.subscribe "message_dropped.active_publisher" do
+  ::Harness.increment "active_publisher.message_dropped"
+end
+
 ::ActiveSupport::Notifications.subscribe "wait_for_async_queue.active_publisher" do |*args|
   event = ::ActiveSupport::Notifications::Event.new(*args)
   ::Harness.timing "active_publisher.waiting_for_async_queue", event.duration

--- a/lib/harness/active_publisher.rb
+++ b/lib/harness/active_publisher.rb
@@ -4,7 +4,7 @@ require "harness"
 require "active_support"
 
 ::ActiveSupport::Notifications.subscribe "async_queue_size.active_publisher" do |_, _, _, _, async_queue_size|
-  ::Harness.count "active_publisher.async_queue_size", async_queue_size
+  ::Harness.gauge "active_publisher.async_queue_size", async_queue_size
 end
 
 ::ActiveSupport::Notifications.subscribe "message_dropped.active_publisher" do

--- a/spec/harness/active_publisher_spec.rb
+++ b/spec/harness/active_publisher_spec.rb
@@ -1,11 +1,46 @@
 require "spec_helper"
 
-RSpec.describe Harness::ActivePublisher do
+describe ::Harness::ActivePublisher do
+  let(:collector) { ::Harness::NullCollector.new }
+
+  before do
+    ::Harness.config.queue = ::Harness::SyncQueue.new
+    ::Harness.config.collector = collector
+  end
+
   it "has a version number" do
     expect(Harness::ActivePublisher::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  describe "async_queue_size.active_publisher" do
+    it "updates the queue size count" do
+      expect(collector).to receive(:count).with("active_publisher.async_queue_size", 1000)
+      ::ActiveSupport::Notifications.instrument "async_queue_size.active_publisher", 1000
+    end
+  end
+
+  describe "message_dropped.active_publisher" do
+    it "increments the message was dropped counter" do
+      expect(collector).to receive(:increment).with("active_publisher.message_dropped")
+      ::ActiveSupport::Notifications.instrument "message_dropped.active_publisher"
+    end
+  end
+
+  describe "wait_for_async_queue.active_publisher" do
+    it "increments the message was dropped counter" do
+      stat = ""
+      duration = 0
+      expect(collector).to receive(:timing) do |the_stat, the_duration|
+        stat = the_stat
+        duration = the_duration
+      end
+
+      ::ActiveSupport::Notifications.instrument "wait_for_async_queue.active_publisher" do
+        sleep 0.1
+      end
+
+      expect(stat).to eq("active_publisher.waiting_for_async_queue")
+      expect(duration).to be >= 0.1
+    end
   end
 end

--- a/spec/harness/active_publisher_spec.rb
+++ b/spec/harness/active_publisher_spec.rb
@@ -14,7 +14,7 @@ describe ::Harness::ActivePublisher do
 
   describe "async_queue_size.active_publisher" do
     it "updates the queue size count" do
-      expect(collector).to receive(:count).with("active_publisher.async_queue_size", 1000)
+      expect(collector).to receive(:gauge).with("active_publisher.async_queue_size", 1000)
       ::ActiveSupport::Notifications.instrument "async_queue_size.active_publisher", 1000
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,9 +5,6 @@ RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
 
-  # Disable RSpec exposing methods globally on `Module` and `main`
-  config.disable_monkey_patching!
-
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
Yay for tests 🎉 

```
Harness::ActivePublisher
  has a version number
  async_queue_size.active_publisher
    updates the queue size count
  message_dropped.active_publisher
    increments the message was dropped counter
  wait_for_async_queue.active_publisher
    increments the message was dropped counter

Finished in 0.11555 seconds (files took 0.1999 seconds to load)
4 examples, 0 failures
```

cc @mmmries 