### PR TITLE
report separate metrics per subscriber/worker/service

### DIFF
--- a/lib/harness/active_publisher.rb
+++ b/lib/harness/active_publisher.rb
@@ -3,11 +3,11 @@ require "harness/active_publisher/version"
 require "harness"
 require "active_support"
 
-DROPPED_METRIC    = ["active_publisher", ENV["service"], "message_dropped"].select.join(".").freeze
-LATENCY_METRIC    = ["active_publisher", ENV["service"], "publish_latency"].select.join(".").freeze
-PUBLISHED_METRIC  = ["active_publisher", ENV["service"], "messages_published"].select.join(".").freeze
-QUEUE_SIZE_METRIC = ["active_publisher", ENV["service"], "async_queue_size"].select.join(".").freeze
-WAIT_METRIC       = ["active_publisher", ENV["service"], "waiting_for_async_queue"].select.join(".").freeze
+DROPPED_METRIC    = ["active_publisher", ENV["service"], "message_dropped"].reject(&:nil?).join(".").freeze
+LATENCY_METRIC    = ["active_publisher", ENV["service"], "publish_latency"].reject(&:nil?).join(".").freeze
+PUBLISHED_METRIC  = ["active_publisher", ENV["service"], "messages_published"].reject(&:nil?).join(".").freeze
+QUEUE_SIZE_METRIC = ["active_publisher", ENV["service"], "async_queue_size"].reject(&:nil?).join(".").freeze
+WAIT_METRIC       = ["active_publisher", ENV["service"], "waiting_for_async_queue"].reject(&:nil?).join(".").freeze
 
 ::ActiveSupport::Notifications.subscribe "async_queue_size.active_publisher" do |_, _, _, _, async_queue_size|
   ::Harness.gauge QUEUE_SIZE_METRIC, async_queue_size

--- a/lib/harness/active_publisher.rb
+++ b/lib/harness/active_publisher.rb
@@ -3,22 +3,28 @@ require "harness/active_publisher/version"
 require "harness"
 require "active_support"
 
+DROPPED_METRIC    = ["active_publisher", ENV["service"], "message_dropped"].select.join(".").freeze
+LATENCY_METRIC    = ["active_publisher", ENV["service"], "publish_latency"].select.join(".").freeze
+PUBLISHED_METRIC  = ["active_publisher", ENV["service"], "messages_published"].select.join(".").freeze
+QUEUE_SIZE_METRIC = ["active_publisher", ENV["service"], "async_queue_size"].select.join(".").freeze
+WAIT_METRIC       = ["active_publisher", ENV["service"], "waiting_for_async_queue"].select.join(".").freeze
+
 ::ActiveSupport::Notifications.subscribe "async_queue_size.active_publisher" do |_, _, _, _, async_queue_size|
-  ::Harness.gauge "active_publisher.async_queue_size", async_queue_size
+  ::Harness.gauge QUEUE_SIZE_METRIC, async_queue_size
 end
 
 ::ActiveSupport::Notifications.subscribe "message_dropped.active_publisher" do
-  ::Harness.increment "active_publisher.message_dropped"
+  ::Harness.increment DROPPED_METRIC
 end
 
 ::ActiveSupport::Notifications.subscribe "message_published.active_publisher" do |*args|
   event = ::ActiveSupport::Notifications::Event.new(*args)
   message_count = event.payload.fetch(:message_count, 1)
-  ::Harness.increment "active_publisher.messages_published", message_count
-  ::Harness.timing "active_publisher.publish_latency", event.duration
+  ::Harness.increment PUBLISHED_METRIC, message_count
+  ::Harness.timing LATENCY_METRIC, event.duration
 end
 
 ::ActiveSupport::Notifications.subscribe "wait_for_async_queue.active_publisher" do |*args|
   event = ::ActiveSupport::Notifications::Event.new(*args)
-  ::Harness.timing "active_publisher.waiting_for_async_queue", event.duration
+  ::Harness.timing WAIT_METRIC, event.duration
 end

--- a/lib/harness/active_publisher.rb
+++ b/lib/harness/active_publisher.rb
@@ -3,11 +3,11 @@ require "harness/active_publisher/version"
 require "harness"
 require "active_support"
 
-DROPPED_METRIC    = ["active_publisher", ENV["service"], "message_dropped"].reject(&:nil?).join(".").freeze
-LATENCY_METRIC    = ["active_publisher", ENV["service"], "publish_latency"].reject(&:nil?).join(".").freeze
-PUBLISHED_METRIC  = ["active_publisher", ENV["service"], "messages_published"].reject(&:nil?).join(".").freeze
-QUEUE_SIZE_METRIC = ["active_publisher", ENV["service"], "async_queue_size"].reject(&:nil?).join(".").freeze
-WAIT_METRIC       = ["active_publisher", ENV["service"], "waiting_for_async_queue"].reject(&:nil?).join(".").freeze
+DROPPED_METRIC    = ["active_publisher", ENV["SERVICE_NAME"], "message_dropped"].reject(&:nil?).join(".").freeze
+LATENCY_METRIC    = ["active_publisher", ENV["SERVICE_NAME"], "publish_latency"].reject(&:nil?).join(".").freeze
+PUBLISHED_METRIC  = ["active_publisher", ENV["SERVICE_NAME"], "messages_published"].reject(&:nil?).join(".").freeze
+QUEUE_SIZE_METRIC = ["active_publisher", ENV["SERVICE_NAME"], "async_queue_size"].reject(&:nil?).join(".").freeze
+WAIT_METRIC       = ["active_publisher", ENV["SERVICE_NAME"], "waiting_for_async_queue"].reject(&:nil?).join(".").freeze
 
 ::ActiveSupport::Notifications.subscribe "async_queue_size.active_publisher" do |_, _, _, _, async_queue_size|
   ::Harness.gauge QUEUE_SIZE_METRIC, async_queue_size


### PR DESCRIPTION
Right now when we are looking at production stats we are seeing the stats getting all mixed up between the subscriber processes vs the rpc processes etc. This PR makes it so that if there is a `SERVICE` environment variable we use that as part of the metric name. This will keep the same behavior as previous releases when there is no environment variable set, but allow us to see more details metrics.

/cc @abrandoned @film42 