### PR TITLE
bump to 1.0 and scope the constants to harness/active_publisher

### DIFF
--- a/harness-active_publisher.gemspec
+++ b/harness-active_publisher.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activesupport", ">= 3.2"
   spec.add_runtime_dependency "harness", ">= 2.0.0"
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/harness/active_publisher.rb
+++ b/lib/harness/active_publisher.rb
@@ -3,28 +3,32 @@ require "harness/active_publisher/version"
 require "harness"
 require "active_support"
 
-DROPPED_METRIC    = ["active_publisher", ENV["SERVICE_NAME"], "message_dropped"].reject(&:nil?).join(".").freeze
-LATENCY_METRIC    = ["active_publisher", ENV["SERVICE_NAME"], "publish_latency"].reject(&:nil?).join(".").freeze
-PUBLISHED_METRIC  = ["active_publisher", ENV["SERVICE_NAME"], "messages_published"].reject(&:nil?).join(".").freeze
-QUEUE_SIZE_METRIC = ["active_publisher", ENV["SERVICE_NAME"], "async_queue_size"].reject(&:nil?).join(".").freeze
-WAIT_METRIC       = ["active_publisher", ENV["SERVICE_NAME"], "waiting_for_async_queue"].reject(&:nil?).join(".").freeze
+module Harness
+  module ActivePublisher
+    DROPPED_METRIC    = ["active_publisher", ENV["SERVICE_NAME"], "message_dropped"].reject(&:nil?).join(".").freeze
+    LATENCY_METRIC    = ["active_publisher", ENV["SERVICE_NAME"], "publish_latency"].reject(&:nil?).join(".").freeze
+    PUBLISHED_METRIC  = ["active_publisher", ENV["SERVICE_NAME"], "messages_published"].reject(&:nil?).join(".").freeze
+    QUEUE_SIZE_METRIC = ["active_publisher", ENV["SERVICE_NAME"], "async_queue_size"].reject(&:nil?).join(".").freeze
+    WAIT_METRIC       = ["active_publisher", ENV["SERVICE_NAME"], "waiting_for_async_queue"].reject(&:nil?).join(".").freeze
 
-::ActiveSupport::Notifications.subscribe "async_queue_size.active_publisher" do |_, _, _, _, async_queue_size|
-  ::Harness.gauge QUEUE_SIZE_METRIC, async_queue_size
-end
+    ::ActiveSupport::Notifications.subscribe "async_queue_size.active_publisher" do |_, _, _, _, async_queue_size|
+      ::Harness.gauge QUEUE_SIZE_METRIC, async_queue_size
+    end
 
-::ActiveSupport::Notifications.subscribe "message_dropped.active_publisher" do
-  ::Harness.increment DROPPED_METRIC
-end
+    ::ActiveSupport::Notifications.subscribe "message_dropped.active_publisher" do
+      ::Harness.increment DROPPED_METRIC
+    end
 
-::ActiveSupport::Notifications.subscribe "message_published.active_publisher" do |*args|
-  event = ::ActiveSupport::Notifications::Event.new(*args)
-  message_count = event.payload.fetch(:message_count, 1)
-  ::Harness.count PUBLISHED_METRIC, message_count
-  ::Harness.timing LATENCY_METRIC, event.duration
-end
+    ::ActiveSupport::Notifications.subscribe "message_published.active_publisher" do |*args|
+      event = ::ActiveSupport::Notifications::Event.new(*args)
+      message_count = event.payload.fetch(:message_count, 1)
+      ::Harness.count PUBLISHED_METRIC, message_count
+      ::Harness.timing LATENCY_METRIC, event.duration
+    end
 
-::ActiveSupport::Notifications.subscribe "wait_for_async_queue.active_publisher" do |*args|
-  event = ::ActiveSupport::Notifications::Event.new(*args)
-  ::Harness.timing WAIT_METRIC, event.duration
+    ::ActiveSupport::Notifications.subscribe "wait_for_async_queue.active_publisher" do |*args|
+      event = ::ActiveSupport::Notifications::Event.new(*args)
+      ::Harness.timing WAIT_METRIC, event.duration
+    end
+  end
 end

--- a/lib/harness/active_publisher/version.rb
+++ b/lib/harness/active_publisher/version.rb
@@ -1,5 +1,5 @@
 module Harness
   module ActivePublisher
-    VERSION = "0.5.0"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
realized while writing another harness plugin that we are putting these constants in a global scope (probably not best idea) ... moved them to a locallly scoped place and remove lock-down of bundler

@film42 @abrandoned 