### PR TITLE
Add message route to publish instrumentation

### DIFF
--- a/lib/harness/active_publisher.rb
+++ b/lib/harness/active_publisher.rb
@@ -21,8 +21,10 @@ module Harness
 
     ::ActiveSupport::Notifications.subscribe "message_published.active_publisher" do |*args|
       event = ::ActiveSupport::Notifications::Event.new(*args)
+      route = event.payload.fetch(:route, "")
+      route = ".#{route.gsub('.', '-')}" unless route.empty?
       message_count = event.payload.fetch(:message_count, 1)
-      ::Harness.count PUBLISHED_METRIC, message_count
+      ::Harness.count PUBLISHED_METRIC + route, message_count
       ::Harness.timing LATENCY_METRIC, event.duration
     end
 

--- a/spec/harness/active_publisher_spec.rb
+++ b/spec/harness/active_publisher_spec.rb
@@ -27,14 +27,19 @@ describe ::Harness::ActivePublisher do
   end
 
   describe "message_published.active_publisher" do
-    it "increments the message was dropped counter" do
+    it "increments the message was published counter" do
       expect(collector).to receive(:count).with("active_publisher.messages_published", 1)
       ::ActiveSupport::Notifications.instrument("message_published.active_publisher") {}
     end
 
-    it "increments the message was dropped counter by the number provided" do
+    it "increments the messages was published counter by the number provided" do
       expect(collector).to receive(:count).with("active_publisher.messages_published", 1000)
       ::ActiveSupport::Notifications.instrument("message_published.active_publisher", :message_count => 1000) {}
+    end
+
+    it "increments the message was published counter with a specified route" do
+      expect(collector).to receive(:count).with("active_publisher.messages_published.test-route", 1)
+      ::ActiveSupport::Notifications.instrument("message_published.active_publisher", :route => "test.route") {}
     end
 
     it "records the publish latency" do


### PR DESCRIPTION
Adds the message route to the publish instrumentation so we can see message volume to each route individually.

See mxenabled/active_publisher#44

CC @film42 